### PR TITLE
Fix rtpstream local port allocation

### DIFF
--- a/src/rtpstream.cpp
+++ b/src/rtpstream.cpp
@@ -1814,7 +1814,7 @@ static int rtpstream_get_localport(int* rtpsocket, int* rtcpsocket)
     int port_number;
     int tries;
     struct sockaddr_storage address;
-    int max_tries = (min_rtp_port < (max_rtp_port - 2)) ? 100 : 1;
+    int max_tries = (min_rtp_port < (max_rtp_port - 2)) ? (max_rtp_port - min_rtp_port) : 1;
 
     debugprint("rtpstream_get_localport\n");
 


### PR DESCRIPTION
Don't hardcode retry counter max value.

After 100 calls with RTP the following error was shown before:

```
2024-06-25      07:35:06.156700 1719300906.156700: Could not bind port for RTP streaming after 100 tries
2024-06-25      07:35:06.156776 1719300906.156776: cannot assign a free audio port to this call - using 0 for [rtpstream_audio_port]
```